### PR TITLE
Do not auto show ammo box attributes for QOL

### DIFF
--- a/addons/editor/functions/fnc_bi_curatorObjectPlaced.sqf
+++ b/addons/editor/functions/fnc_bi_curatorObjectPlaced.sqf
@@ -1,7 +1,8 @@
 /*
  * Author: Bohemia Interactive, mharis001
  * Handles placement of an object by Zeus.
- * Edited to allow control over radio messages.
+ * Edited to allow control over radio messages and not automatically
+ * show inventory attributes for ammo box objects.
  *
  * Arguments:
  * 0: Curator (not used) <OBJECT>
@@ -31,7 +32,7 @@ BIS_fnc_curatorObjectPlaced_mouseOver = curatorMouseOver;
 
 private _curatorInfoType = getText (configFile >> "CfgVehicles" >> typeOf _object >> "curatorInfoType");
 
-if (getNumber (configFile >> _curatorInfoType >> "filterAttributes") == 0) then {
+if (getNumber (configFile >> _curatorInfoType >> "filterAttributes") == 0 && {!(_object isKindOf "ReammoBox_F")}) then {
     _object call BIS_fnc_showCuratorAttributes;
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- title, for QOL since placing other objects does not show attributes